### PR TITLE
add realloc and get_allocator_size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # Build cache
 /target
+
+#Idea
+.idea

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 dependencies = [
  "lock_api",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ strip = true
 codegen-units = 1
 
 [dependencies]
-spin = "0.9.8"
+spin = "0.10.0"
 talc = "4.4.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,3 +50,14 @@ pub unsafe extern "C" fn free(ptr: *mut c_void) {
     let origin_ptr = NonNull::new_unchecked(origin_ptr as *mut u8);
     ALLOCATOR.lock().free(origin_ptr, layout);
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn get_allocator_size(ptr: *mut c_void) -> usize {
+    if ptr.is_null() {
+        return 0;
+    }
+    let user_ptr_as_usize = ptr as *mut usize;
+    let metadata_ptr = user_ptr_as_usize.sub(1);
+    let size = metadata_ptr.read();
+    size
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,9 @@
 
 use core::alloc::Layout;
 use core::ffi::c_void;
-use core::{panic::PanicInfo, ptr::NonNull};
+use core::{panic::PanicInfo, ptr::NonNull, ptr};
 use talc::{ClaimOnOom, Span, Talc, Talck};
+use core::cmp; // Import cmp for min
 
 #[panic_handler]
 unsafe fn panic(_info: &PanicInfo) -> ! {
@@ -16,7 +17,7 @@ static ALLOCATOR: Talck<spin::Mutex<()>, ClaimOnOom> =
 
 #[no_mangle]
 pub unsafe extern "C" fn heap_init(address: *mut u8, size: usize) -> bool {
-    let arena = Span::from_base_size(address as *mut u8, size);
+    let arena = Span::from_base_size(address, size);
     ALLOCATOR.lock().claim(arena).is_ok()
 }
 
@@ -31,7 +32,7 @@ pub unsafe extern "C" fn malloc(size: usize) -> *mut c_void {
             size_ptr.write(size);
             (size_ptr.offset(1) as *mut u8) as *mut c_void
         }
-        Err(_) => return core::ptr::null_mut(),
+        Err(_) => ptr::null_mut(),
     }
 }
 
@@ -60,4 +61,31 @@ pub unsafe extern "C" fn get_allocator_size(ptr: *mut c_void) -> usize {
     let metadata_ptr = user_ptr_as_usize.sub(1);
     let size = metadata_ptr.read();
     size
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn realloc(ptr: *mut c_void, new_size: usize) -> *mut c_void {
+    if ptr.is_null() {
+        return malloc(new_size);
+    }
+
+    if new_size == 0 {
+        free(ptr);
+        return ptr::null_mut();
+    }
+
+    let old_size = get_allocator_size(ptr);
+    if new_size == old_size {
+        return ptr;
+    }
+
+    let new_ptr = malloc(new_size);
+
+    if new_ptr.is_null() {
+        return ptr::null_mut();
+    }
+    let copy_size = cmp::min(old_size, new_size);
+    ptr::copy_nonoverlapping(ptr as *const u8, new_ptr as *mut u8, copy_size);
+    free(ptr);
+    new_ptr
 }


### PR DESCRIPTION
We add two function
- `realloc`
- `get_allocator_size`

The actual effect of these methods should be the same as realloc and sizeof in libc